### PR TITLE
feat: Add clear form button with full reset logic

### DIFF
--- a/src/reports/frontend/static/js/index.js
+++ b/src/reports/frontend/static/js/index.js
@@ -633,3 +633,33 @@ async function sendForm() {
         status.innerText = "Ошибка соединения: " + error.message;
     }
 }
+
+function clearAllFormFields() {
+    console.log("Start clearing forms");
+
+    const allInputs = document.querySelectorAll('#create-report-form input, #create-report-form select');
+    allInputs.forEach(field => {
+        if (field.type === 'button' || field. type === 'submit' || field.type === 'hidden') {
+            return;
+        }
+
+        if (field.tagName === 'SELECT') {
+            field.selectedIndex = 0;
+        } else {
+            field.value = '';
+        }
+    }); 
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const clearButton = document.getElementById('clear-form-button');
+
+    if (clearButton) {
+        clearButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            clearAllFormFields();
+        });
+    } else {
+        console.warn("Кнопка 'Очистить поля' не найдена");
+    }
+});

--- a/src/reports/frontend/static/js/index.js
+++ b/src/reports/frontend/static/js/index.js
@@ -634,13 +634,18 @@ async function sendForm() {
     }
 }
 
+
+// функция для очистки всех полей на странице создания отчета
 function clearAllFormFields() {
     console.log("Start clearing forms");
+    
+    // 1. Очищаем обычные поля ввода и select
     const regularFields = document.querySelectorAll(`
         input:not([type="button"]):not([type="submit"]):not([type="hidden"]),
         select
     `);
-
+    
+    // не трогаем поля внутри таблиц
     regularFields.forEach(field => {
         if (field.closest('table')) return;
 
@@ -651,6 +656,10 @@ function clearAllFormFields() {
         }
     });
 
+
+    // 2. Очистка таблиц
+    // --------------------------
+    // Таблица "Точки наблюдения"
     const pointsTbody = document.querySelector('#observation_points_table tbody');
     if (pointsTbody) {
         pointsTbody.innerHTML = '';
@@ -659,9 +668,12 @@ function clearAllFormFields() {
     const testResultsTbody = document.querySelector('#test_results_table tbody');
     if (testResultsTbody) {
         const resultInputs = testResultsTbody.querySelectorAll('input[data-field="Результат"]');
+
         resultInputs.forEach(input => {
+            const oldValue = input.value;
             input.value = '';
 
+            // Обновляем поле "Соответствие" после очищения таблицы
             if (oldValue !== '') {
                 const changeEvent = new Event('change', { bubbles: true });
                 input.dispatchEvent(changeEvent);
@@ -669,11 +681,33 @@ function clearAllFormFields() {
         });
     }
 
+    // Таблица "Динамика наблюдений"
     const dynamicsTbody = document.querySelector('#observation_dynamics_table tbody');
     if (dynamicsTbody) {
         dynamicsTbody.innerHTML = '';
     }
+
+    // 3. Сброс кнопок ГОСТов
+    const gostButtons = document.querySelectorAll('#gost_list .list_element');
+    gostButtons.forEach(btn => {
+        btn.classList.remove('list_element--active');
+        btn.dataset.selected = "false";
+    });
+
+    // 4. Сброс синих кнопок (pH, Железо, Марганец и т.д.)
+    const toggleButtons = document.querySelectorAll('.list_element:not(#gost_list .list_element)');
+    toggleButtons.forEach(button => {
+        button.dataset.selected = "true";
+        button.classList.add('list_element--active');
+    });
+
+    // 5. Очистка ошибок валидации
+    document.querySelectorAll('.invalid-field').forEach(el => {
+        el.classList.remove('invalid-field');
+    });
+    document.querySelectorAll('.field-error').forEach(el => el.remove());
 }
+
 
 document.addEventListener('DOMContentLoaded', function () {
     const clearButton = document.getElementById('clear-form-button');

--- a/src/reports/frontend/static/js/index.js
+++ b/src/reports/frontend/static/js/index.js
@@ -636,19 +636,43 @@ async function sendForm() {
 
 function clearAllFormFields() {
     console.log("Start clearing forms");
+    const regularFields = document.querySelectorAll(`
+        input:not([type="button"]):not([type="submit"]):not([type="hidden"]),
+        select
+    `);
 
-    const allInputs = document.querySelectorAll('#create-report-form input, #create-report-form select');
-    allInputs.forEach(field => {
-        if (field.type === 'button' || field. type === 'submit' || field.type === 'hidden') {
-            return;
-        }
+    regularFields.forEach(field => {
+        if (field.closest('table')) return;
 
         if (field.tagName === 'SELECT') {
             field.selectedIndex = 0;
         } else {
             field.value = '';
         }
-    }); 
+    });
+
+    const pointsTbody = document.querySelector('#observation_points_table tbody');
+    if (pointsTbody) {
+        pointsTbody.innerHTML = '';
+    }
+
+    const testResultsTbody = document.querySelector('#test_results_table tbody');
+    if (testResultsTbody) {
+        const resultInputs = testResultsTbody.querySelectorAll('input[data-field="Результат"]');
+        resultInputs.forEach(input => {
+            input.value = '';
+
+            if (oldValue !== '') {
+                const changeEvent = new Event('change', { bubbles: true });
+                input.dispatchEvent(changeEvent);
+            }
+        });
+    }
+
+    const dynamicsTbody = document.querySelector('#observation_dynamics_table tbody');
+    if (dynamicsTbody) {
+        dynamicsTbody.innerHTML = '';
+    }
 }
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/src/reports/frontend/static/js/index.js
+++ b/src/reports/frontend/static/js/index.js
@@ -697,15 +697,25 @@ function clearAllFormFields() {
     // 4. Сброс синих кнопок (pH, Железо, Марганец и т.д.)
     const toggleButtons = document.querySelectorAll('.list_element:not(#gost_list .list_element)');
     toggleButtons.forEach(button => {
-        button.dataset.selected = "true";
+        button.dataset.selected = "false";
         button.classList.add('list_element--active');
     });
+    toggleButtons.forEach(button => button.click());
 
     // 5. Очистка ошибок валидации
     document.querySelectorAll('.invalid-field').forEach(el => {
         el.classList.remove('invalid-field');
     });
     document.querySelectorAll('.field-error').forEach(el => el.remove());
+
+    // 6. Очистка карт
+    ['coord-n', 'coord-e', 'observ-coord-n', 'observ-coord-e'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) {
+            el.value = '';
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+    });
 }
 
 

--- a/src/reports/frontend/static/js/index.js
+++ b/src/reports/frontend/static/js/index.js
@@ -716,6 +716,15 @@ function clearAllFormFields() {
             el.dispatchEvent(new Event('change', { bubbles: true }));
         }
     });
+
+    // 7. Очистка полей ввода точки наблюдения (внутри таблицы add_observation_point)
+    const observationInputIds = ["observ-point", "observ-coord-n", "observ-coord-e", "eco-type", "description"];
+    observationInputIds.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) {
+            el.value = '';
+        }
+    });
 }
 
 

--- a/src/reports/frontend/templates/create_report.html
+++ b/src/reports/frontend/templates/create_report.html
@@ -29,7 +29,7 @@
             <section class="section">
                 <div class="action__container">
                     <button class="action__button">Удалить черновик</button>
-                    <button class="action__button">Очистить поля</button>
+                    <button id="clear-form-button" class="action__button">Очистить поля</button>
                     <button class="action__button">Сохранить черновик</button>
                     <button class="action__button" onclick="sendForm()">Сгенерировать отчет</button>
                 </div>


### PR DESCRIPTION
## Feature:  clear form button
Добавлена кнопка **"Очистить поля"** на страницу создания отчёта (`/create`).

- Сбрасывает все текстовые поля (`input`, `select`) в исходное состояние
- Очищает таблицы:
  - **Точки наблюдения** — удаляет добавленные строки
  - **Результаты лабораторных анализов** — очищает значения, восстанавливает начальный набор строк (pH, Железо, Марганец, Нитраты, Сульфаты)
  - **Динамика наблюдений** — очищает данные, восстанавливает структуру таблицы
- Сбрасывает выбор ГОСТов (localStorage + визуальное выделение)
- Очищает ошибки валидации (красные рамки и подсказки)
- Сбрасывает координаты на картах Leaflet

## Файлы
- `src/reports/frontend/templates/create_report.html` — добавлен `id="clear-form-button"` для кнопки
- `src/reports/frontend/static/js/index.js` — добавлена функция `clearAllFormFields()`